### PR TITLE
docs: clarify baseline deployment name must match pricing config key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ AZURE_MODEL_ROUTER_DEPLOYMENT=model-router
 # Azure OpenAI endpoint (for baseline model)
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 AZURE_OPENAI_KEY=your-azure-openai-api-key
+# Must match a key in the pricing section of your config file (e.g. gpt-4o, gpt-5).
+# If you use a custom deployment name, add a matching entry to configs/default.yaml
+# under pricing: using your exact deployment name. Otherwise baseline costs show as $0.00.
 AZURE_BASELINE_DEPLOYMENT=gpt-5
 
 # Judge model (defaults to same endpoint as baseline; override to use a different model)

--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,9 @@ AZURE_MODEL_ROUTER_DEPLOYMENT=model-router
 # Azure OpenAI endpoint (for baseline model)
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 AZURE_OPENAI_KEY=your-azure-openai-api-key
-# Must match a key in the pricing section of your config file (e.g. gpt-4o, gpt-5).
-# If you use a custom deployment name, add a matching entry to configs/default.yaml
-# under pricing: using your exact deployment name. Otherwise baseline costs show as $0.00.
+# Must match a key in the pricing section of the config file you run (e.g. gpt-4o, gpt-5).
+# If you use a custom deployment name, add a matching entry under pricing: in that same config
+# using your exact deployment name. Otherwise baseline costs show as $0.00.
 AZURE_BASELINE_DEPLOYMENT=gpt-5
 
 # Judge model (defaults to same endpoint as baseline; override to use a different model)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -139,7 +139,7 @@ copy .env.example .env     # Windows
 ```
 Open `.env` and set the four endpoint URLs and API keys (router, baseline, judge, optional Foundry project). The file is in `.gitignore`, so your secrets won't be committed.
 
-> **Note:** The value you set for `AZURE_BASELINE_DEPLOYMENT` must match a key in the `pricing` section of your config file. If you use a custom deployment name such as `gpt-4o-baseline`, add a matching entry under `pricing:` in `configs/default.yaml` with the same input/output rates. Otherwise baseline costs will show as $0.00 and the cost comparison will be inaccurate. This applies whether you are using Quick Deploy or Custom Deploy.
+> **Note:** The value you set for `AZURE_BASELINE_DEPLOYMENT` must match a key in the `pricing` section of the config file you run (e.g. `configs/default.yaml`). If you use a custom deployment name such as `gpt-4o-baseline`, add a matching entry under `pricing:` in that same config with the same input/output rates; otherwise baseline costs will show as $0.00 and the cost comparison will be inaccurate.
 
 ### 2. Pick or edit a config
 - `configs/quick_test.yaml` — small, fast (~10 prompts) — good first run.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -139,6 +139,8 @@ copy .env.example .env     # Windows
 ```
 Open `.env` and set the four endpoint URLs and API keys (router, baseline, judge, optional Foundry project). The file is in `.gitignore`, so your secrets won't be committed.
 
+> **Note:** The value you set for `AZURE_BASELINE_DEPLOYMENT` must match a key in the `pricing` section of your config file. If you use a custom deployment name such as `gpt-4o-baseline`, add a matching entry under `pricing:` in `configs/default.yaml` with the same input/output rates. Otherwise baseline costs will show as $0.00 and the cost comparison will be inaccurate. This applies whether you are using Quick Deploy or Custom Deploy.
+
 ### 2. Pick or edit a config
 - `configs/quick_test.yaml` — small, fast (~10 prompts) — good first run.
 - `configs/default.yaml` — full benchmark (100 prompts).


### PR DESCRIPTION
## Summary

- Adds a comment in `.env.example` above `AZURE_BASELINE_DEPLOYMENT` explaining that the value must match a key in the `pricing` section of the config file
- Adds a callout block in `QUICKSTART.md` (Part 2, credentials step) with the same guidance and an example of how to add a custom entry

Discovered while running evaluations against a Quick Deploy setup. If you use a descriptive deployment name (e.g. `gpt-4o-baseline`) that doesn't match any `pricing:` key in your config, baseline costs are recorded as $0.0000 with no warning — making the cost comparison inaccurate. The underlying silent-failure is tracked in #2.

## Changes

- `.env.example`: three-line comment above `AZURE_BASELINE_DEPLOYMENT`
- `QUICKSTART.md`: one-sentence callout block after the credentials setup step

## Test plan

- [x] `pytest tests/ -v -m "not integration"` — 165 passed, 2 pre-existing failures (optional `[foundry]` extras not installed, unrelated to this change)
- [x] `ruff check src/ tests/ scripts/` — all checks passed
- [x] No code changes, documentation only